### PR TITLE
Moving all Alma pre-commit hooks under the same hood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .mypy_cache/
 *.egg-info/
 __pycache__/
+.idea/*

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,9 @@
   entry: check-file-change
   language: python
   files: ^$
+- id: check-comments
+  name: Count comments in files
+  description: Check if file contains at least more than 0% of comments
+  entry: pre_commit_hooks/check-comments.sh
+  language: script
+  types: [python]

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Some Alma hooks for pre-commit.
 See also: https://github.com/pre-commit/pre-commit
 
 
-### Using pre-commit-hooks with pre-commit
+## Using pre-commit-hooks with pre-commit
 
-Add this to your `.pre-commit-config.yaml`
+Add this to your `.pre-commit-config.yaml`.
+Only use the sections of the checks you want to use (each section starts with `- id: a-check-name`.
 
 ```yaml
 -   repo: https://github.com/alma/pre-commit-hooks
@@ -21,12 +22,25 @@ Add this to your `.pre-commit-config.yaml`
         - config.dev.yaml:eacaec4b8c4665dfce2d0e082acd0d39787457da
         - config.prod.yaml:eacaec4b8c4665dfce2d0e082acd0d39787457da
         - --
+    - id: check-comments
 ```
 
-### Hooks available
+## Hooks available
 
-#### check-file-change
+The hooks below are available in this repository.
+
+### check-file-change
 
 Make sure files didn't change.
 You must provide list of target files with their expected checksum in a given algorithm. (Default is sha1)
 You can change the algorithm with the ``--algorithm=sha256`` option.
+
+### check-comment
+
+Checks that the modified files contain at least one line of comment.
+
+#### Dependencies
+
+This hook relies on (should be installed on the local machine / VM):
+* [cloc](https://github.com/AlDanial/cloc)
+* [jq](https://stedolan.github.io/jq/)

--- a/pre_commit_hooks/check-comments.sh
+++ b/pre_commit_hooks/check-comments.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+DEBUG=${DEBUG:=0}
+[[ "$DEBUG" = "1" ]] && set -o xtrace
+
+if ! command which cloc &>/dev/null; then
+  >&2 echo 'cloc command not found, please install it'
+  exit 1
+fi
+
+if ! command which jq &>/dev/null; then
+  >&2 echo 'jq command not found, please install it'
+  exit 1
+fi
+
+has_errors=0
+
+function check_file
+{
+    local file_path="$1"
+    local stats=$(cloc --json "$file_path")
+    if [ -z "$stats" ]
+    then
+        # no stats, empty file?
+        return
+    fi
+
+    local lines_count=$(echo "$stats" | jq '.header.n_lines')
+    if [ "$lines_count" -le 1 ]
+    then
+        # empty file
+        return
+    fi
+
+    local comments_count=$(echo "$stats" | jq '.SUM.comment')
+    if [ "$comments_count" -eq 0 ]
+    then
+        >&2 echo "File $@ contains 0 comments"
+        has_errors=1
+    fi
+
+    # all good!
+    return
+}
+
+for file_path in "$@"
+do
+    check_file "$file_path"
+done
+exit $has_errors


### PR DESCRIPTION
We should have all Alma `pre-commit` hooks in the same repository (ads it seems it should be done).
Doing this small refactoring before we can add more.

[`pre-commit-cloc`](https://github.com/alma/pre-commit-cloc) that just contains counting comment should be marked obsolete/deprecated.  
The hook is here now.