### PR TITLE
fix: don't check exclude if the option wasn't used

### DIFF
--- a/pre_commit_hooks/check-branch-name.sh
+++ b/pre_commit_hooks/check-branch-name.sh
@@ -25,7 +25,7 @@ fi
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
-if [[ $BRANCH_NAME =~ $EXCLUDE_BRANCH_REGEX ]]; then
+if [[ -n $EXCLUDE_BRANCH_REGEX && $BRANCH_NAME =~ $EXCLUDE_BRANCH_REGEX ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
This was checked every time, and (at least for my setup), every branch matched the empty regex, so the check always passed even when the branch had a wrong name.